### PR TITLE
release into ci on tags so puppet doesn't throw errors

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,15 +20,18 @@ rpm-build:
     name: "$CI_PROJECT_NAME-$CI_COMMIT_TAG"
 
 
-rpm-deploy:
-  variables:
-    RLS_SCRIPT: "./tmp/ondemand-packaging/release.py"
-    RLS_KEY: "/systems/osc_certs/ssh/ondemand-packaging/id_rsa"
-    RLS_OUTPUT: "./tmp/output/*"
-    SECTION: "main"
+rpm-deploy-ci:
   stage: deploy
   only:
     - tags
   script:
-    - if [[ "$CI_COMMIT_TAG" =~ .*_.* ]]; then export SECTION=ci; fi
-    - $RLS_SCRIPT --debug --pkey $RLS_KEY -c $SECTION $RLS_OUTPUT
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c ci ./tmp/output/*
+rpm-deploy:
+  stage: deploy
+  only:
+    - tags
+  except:
+    variables:
+      - $CI_COMMIT_TAG =~ /.*_.*/
+  script:
+    - ./tmp/ondemand-packaging/release.py --debug --pkey /systems/osc_certs/ssh/ondemand-packaging/id_rsa -c main ./tmp/output/*

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,7 @@
+variables:
+ # older versions of git have issues fetching.
+ GIT_STRATEGY: clone
+
 before_script:
   - docker info
   - '[ -d tmp ] || mkdir tmp'


### PR DESCRIPTION
Just like the [PR](https://github.com/OSC/bc_osc_rstudio_server/pull/27) in the RStudio Server so that we don't get a lot of puppet errors in dev when packages exist in latest but not ci.