### PR TITLE
raise an error in submit to stop folks from using the app

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,4 +1,9 @@
 <%-
+
+  raise StandardError.new("This application no longer in use. We'll be removing it
+  in the coming days.  Please use the \"RStudio Server (Owens and Pitzer)\" application and
+  choose the Pitzer cluster instead.")
+
   ppn   = num_cores.blank? ? 40 : num_cores.to_i
   props = case node_type
           when "hugemem"


### PR DESCRIPTION
With the additions in https://github.com/OSC/bc_osc_rstudio_server to allow for pitzer (and pitzer expansion) this app is no longer useful.

However, when we deploy some jobs may still be running, so to let those jobs drain we still need something installed. So we'll have this app still but it won't allow users to submit anymore.

Once we remove the rpms from all the nodes, we can archive this repo and update the README and so on. 